### PR TITLE
Add filter for handler func reflect magic

### DIFF
--- a/redis/handler/server.go
+++ b/redis/handler/server.go
@@ -12,8 +12,8 @@ type Server struct {
 	t HandlerTable
 }
 
-func NewServer(o interface{}) (*Server, error) {
-	t, err := NewHandlerTable(o)
+func NewServer(o interface{}, f func(string) bool) (*Server, error) {
+	t, err := NewHandlerTable(o, f)
 	if err != nil {
 		return nil, err
 	}
@@ -27,8 +27,8 @@ func NewServerWithTable(t HandlerTable) (*Server, error) {
 	return &Server{t}, nil
 }
 
-func MustServer(o interface{}) *Server {
-	return &Server{MustHandlerTable(o)}
+func MustServer(o interface{}, f func(string) bool) *Server {
+	return &Server{MustHandlerTable(o, f)}
 }
 
 func (s *Server) Dispatch(arg0 interface{}, respArg resp.Resp) (resp.Resp, error) {

--- a/redis/handler/server_test.go
+++ b/redis/handler/server_test.go
@@ -38,9 +38,21 @@ func testmapcount(t *testing.T, m1, m2 map[string]int) {
 	}
 }
 
+func (h *testHandler) filter(name string) bool {
+	if len(name) == 0 {
+		return true
+	}
+
+	if name[0] < 'A' || name[0] > 'Z' {
+		return true
+	}
+
+	return false
+}
+
 func TestHandlerFunc(t *testing.T) {
 	h := &testHandler{make(map[string]int)}
-	s, err := NewServer(h)
+	s, err := NewServer(h, h.filter)
 	assert.ErrorIsNil(t, err)
 	key1, key2, key3, key4 := "key1", "key2", "key3", "key4"
 	s.t["get"](nil)
@@ -59,7 +71,7 @@ func TestHandlerFunc(t *testing.T) {
 
 func TestServerServe(t *testing.T) {
 	h := &testHandler{make(map[string]int)}
-	s, err := NewServer(h)
+	s, err := NewServer(h, h.filter)
 	assert.ErrorIsNil(t, err)
 	resp, err := resp.Decode(bufio.NewReader(bytes.NewReader([]byte("*2\r\n$3\r\nset\r\n$3\r\nfoo\r\n"))))
 	assert.ErrorIsNil(t, err)


### PR DESCRIPTION
Mainly used to support qdb handler run and close func can be exported.
So we can use handler.Run() or handler.Close() for a better control.
